### PR TITLE
Add apt-based R setup

### DIFF
--- a/.setup/install_r_packages.sh
+++ b/.setup/install_r_packages.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Install required R packages for MainMethod.R
+set -e
+
+Rscript - <<'RSCRIPT'
+packages <- c("EFAtools", "Gifi")
+install.packages(packages, repos = "https://cloud.r-project.org")
+RSCRIPT

--- a/.setup/setup.sh
+++ b/.setup/setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+# Install R packages required by the analysis
+"$(dirname "$0")"/install_r_packages.sh

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Before EFA, the script now checks variable suitability using the KMO and Bartlet
    ```bash
    conda env create -f environment.yml
    ```
-2. **R packages** – install the packages listed at the top of `MainMethod.R` (dplyr, EFAtools, lavaan, etc.).
+2. **R packages** – most libraries are installed via `apt.txt` during setup.
+   Remaining packages (EFAtools and Gifi) can be installed with:
+   ```bash
+   ./.setup/install_r_packages.sh
+   ```
 
 ## Running the Analysis
 - **Run preprocessing**

--- a/apt.txt
+++ b/apt.txt
@@ -1,2 +1,17 @@
 # apt.txt
 r-base
+r-cran-dplyr
+r-cran-boot
+r-cran-lavaan
+r-cran-mgcv
+r-cran-polycor
+r-cran-psych
+r-cran-readxl
+r-cran-stringr
+r-cran-dosnow
+r-cran-doparallel
+r-cran-foreach
+r-cran-ggplot2
+r-cran-reshape2
+r-cran-wgcna
+r-cran-matrix


### PR DESCRIPTION
## Summary
- install R dependencies with apt
- slim down install script to EFAtools and Gifi
- document new setup in README

## Testing
- `Rscript --version`
- `bash ./.setup/install_r_packages.sh`
- `Rscript MainMethod.R`

------
https://chatgpt.com/codex/tasks/task_e_687f5012cb7c832198752e55031b441e