### PR TITLE
Simplify GAM to use only factor scores

### DIFF
--- a/MainMethod.R
+++ b/MainMethod.R
@@ -614,29 +614,12 @@ F_hat <- X_std %*% Wten
 colnames(F_hat) <- colnames(Lambda0)
 rownames(F_hat) <- rownames(df_mix2_clean)
 
-# --- 20.2  Prepare nominal predictors --------------------------------------
-collapse_rare <- function(f, threshold = 0.05) {
-  tab <- prop.table(table(f))
-  rare <- names(tab)[tab < threshold]
-  f_new <- as.character(f)
-  f_new[f_new %in% rare] <- "Other"
-  factor(f_new)
-}
-
-nom_collapsed <- df_nom %>% mutate(across(everything(), collapse_rare))
-is_large <- function(v) nlevels(v) > 10
-large_noms <- names(Filter(is_large, nom_collapsed))
-small_noms <- names(Filter(Negate(is_large), nom_collapsed))
-
-# --- 20.3  Fit GAM of productivity on factor scores ------------------------
-gam_df <- data.frame(prod_index = y_prod, F_hat, nom_collapsed)
+# --- 20.2  Fit GAM of productivity on factor scores -----------------------
+gam_df <- data.frame(prod_index = y_prod, F_hat)
 gam_df <- na.omit(gam_df)
 
 smooth_terms <- paste0("s(", colnames(F_hat), ")")
-small_terms  <- if (length(small_noms)) paste(small_noms, collapse = " + ") else NULL
-large_terms  <- if (length(large_noms)) paste0("s(", large_noms, ", bs='re')", collapse = " + ") else NULL
-all_terms <- c(smooth_terms, small_terms, large_terms)
-gam_form <- as.formula(paste("prod_index ~", paste(all_terms, collapse = " + ")))
+gam_form <- as.formula(paste("prod_index ~", paste(smooth_terms, collapse = " + ")))
 
 gam_fit <- mgcv::gam(gam_form, data = gam_df, method = "REML", select = TRUE)
 print(summary(gam_fit)$s.table)
@@ -669,7 +652,7 @@ if (!is.null(param_terms) && nrow(param_terms) > 0) {
 }
 
 # 5. Refit using only significant parametric terms and compare AIC
-refit_terms <- c(smooth_terms, signif_terms, large_terms)
+refit_terms <- c(smooth_terms, signif_terms)
 if (length(refit_terms) == 0) {
   refit_form <- as.formula("prod_index ~ 1")
 } else {


### PR DESCRIPTION
## Summary
- remove nominal predictor handling from GAM phase
- fit GAM only on the latent factor scores

## Testing
- `Rscript -e "library(mgcv); sessionInfo()"`

------
https://chatgpt.com/codex/tasks/task_e_687fd260f0b08321893c654448ee2436