### PR TITLE
Add semtools dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Before EFA, the script now checks variable suitability using the KMO and Bartlet
    ```bash
    ./.setup/setup.sh
    ```
-   This script reads `apt.txt` (which includes `r-base`) and installs
-   the EFAtools and Gifi packages.
+   This script reads `apt.txt` (which includes `r-base` and `r-cran-semtools`) and installs
+   the EFAtools, Gifi and semTools packages.
 
 ## Running the Analysis
 - **Run preprocessing**

--- a/apt.txt
+++ b/apt.txt
@@ -3,6 +3,7 @@ r-base
 r-cran-dplyr
 r-cran-boot
 r-cran-lavaan
+r-cran-semtools
 r-cran-mgcv
 r-cran-polycor
 r-cran-psych

--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
   - r-boot
   - r-gifi
   - r-lavaan
+  - r-semtools
   - r-mgcv
   - r-polycor
   - r-psych


### PR DESCRIPTION
## Summary
- include `r-cran-semtools` in `apt.txt`
- add `r-semtools` to the R packages in `environment.yml`
- document the new dependency in the README under R setup instructions

## Testing
- `python -m py_compile helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_6880cd1d42d083218c8b67ed765f1866