### PR TITLE
Fix R setup to run MainMethod.R

### DIFF
--- a/.setup/install_r_packages.sh
+++ b/.setup/install_r_packages.sh
@@ -4,6 +4,6 @@
 set -e
 
 Rscript - <<'RSCRIPT'
-packages <- c("EFAtools", "Gifi")
+packages <- c("EFAtools", "Gifi", "mgcViz", "mediation")
 install.packages(packages, repos = "https://cloud.r-project.org")
 RSCRIPT


### PR DESCRIPTION
## Summary
- update R setup to install `mgcViz` and `mediation`
- verified `MainMethod.R` now runs without missing package errors

## Testing
- `bash .setup/setup.sh`
- `Rscript MainMethod.R`

------
https://chatgpt.com/codex/tasks/task_e_6882352bc6fc832182a5eb4a39eebc8a