### PR TITLE
Add missing R dependencies for MainMethod

### DIFF
--- a/.setup/install_r_packages.sh
+++ b/.setup/install_r_packages.sh
@@ -4,6 +4,6 @@
 set -e
 
 Rscript - <<'RSCRIPT'
-packages <- c("EFAtools", "Gifi", "mgcViz", "mediation", "semTools", "blavaan")
+packages <- c("EFAtools", "Gifi", "mgcViz", "mediation", "semTools")
 install.packages(packages, repos = "https://cloud.r-project.org")
 RSCRIPT

--- a/apt.txt
+++ b/apt.txt
@@ -16,6 +16,8 @@ r-cran-reshape2
 r-cran-tidyr
 r-cran-wgcna
 r-cran-matrix
+r-cran-rstan
+r-cran-gamm4
 
 r-cran-mvtnorm
 r-cran-sandwich


### PR DESCRIPTION
## Summary
- include rstan and gamm4 system packages for running MainMethod.R
- streamline R package setup script and drop heavy blavaan dependency

## Testing
- `Rscript MainMethod.R >/tmp/mainlog && tail -n 20 /tmp/mainlog`


------
https://chatgpt.com/codex/tasks/task_e_68a314b1e1108321a1692b00c7f9dbb5